### PR TITLE
Track fetch output and fix fetch bundle conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,6 @@ CLAUDE.md
 downloaded/*
 !downloaded/.gitkeep
 
-# Processed data (keep directory)
-processed/*
-!processed/.gitkeep
-
 # Generated API output (api/)
 api/node/**/*.jsonld
 api/*.jsonld

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'ammitto', github: 'ammitto/ammitto', branch: 'main'
 gem 'nokogiri', '~> 1.18.0'
 
 # Schema validation
-gem 'json-schema', '~> 4.0'
+gem 'json-schema', '~> 5.0'
 
 group :development do
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'ammitto', github: 'ammitto/ammitto', branch: 'main'
 gem 'nokogiri', '~> 1.18.0'
 
 # Schema validation
-gem 'json-schema', '~> 5.0'
+gem 'json-schema', '~> 4.0'
 
 group :development do
   gem 'rake'


### PR DESCRIPTION
Scheduled fetch downloaded this source every day and discarded the result, because `.gitignore` excluded `processed/`. New entries never reached the repository. Dropped the ignore rule so fetch output is tracked and each run persists what it downloaded.

Fetch could not install its bundle either: this `Gemfile` asked for `json-schema ~> 5.0` while the gem's gemspec allows `~> 4.0`, so `bundle install` failed with `version solving has failed`. Pinned to `~> 4.0`, matching data-ch and data-uk. This repository does not call json-schema directly.

No workflow change is needed here: `fetch.yml` already restricts its commit and issue-filing steps to the default branch.
